### PR TITLE
Shim path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,5 @@
 # harvard.cs50.debug
 
-## Installation
-
-This plugin will not function properly without the below.
-
-Apply the following 4 PRs to your existing installation of `c9.ide.run.debug`:
-[38](https://github.com/c9/c9.ide.run.debug/pull/38),
-[39](https://github.com/c9/c9.ide.run.debug/pull/39),
-[40](https://github.com/c9/c9.ide.run.debug/pull/40), and
-[41](https://github.com/c9/c9.ide.run.debug/pull/41)
-
-And apply the following PR to your existing installation of `c9.ide.run`:
-[16](https://github.com/c9/c9.ide.run/pull/16)
-
-Note that the above steps are obsolete once all PRs are accepted into core and
-published to production.
-
-Then you may install this plugin and reload the workspace.
-
 ## Usage
 
 This plugin adds several Cloud9 commands that allows execution of the

--- a/bin/debug50
+++ b/bin/debug50
@@ -24,7 +24,7 @@ fi
 PID=$$
 
 # SIGUSR1 signals to begin the shim
-SHIM="/home/ubuntu/bin/c9gdbshim.js"
+SHIM="/home/ubuntu/.c9/bin/c9gdbshim.js"
 trap "node $SHIM $@; $C9 gdb50stop $PID; echo; exit 0" SIGUSR1
 
 # give PID to proxy for monitoring

--- a/debug.js
+++ b/debug.js
@@ -43,7 +43,7 @@ define(function(require, exports, module) {
         var SETTING_VER="project/cs50/debug/@ver";
 
         // version of debug50 file
-        var DEBUG_VER=2;
+        var DEBUG_VER=3;
 
         /***** Methods *****/
 
@@ -55,7 +55,7 @@ define(function(require, exports, module) {
             // To be used by standard run system.
             run.addRunner("Debug50", {
                 caption: "Debug50",
-                script: ['node /home/ubuntu/bin/c9gdbshim.js "$file" $args'],
+                script: ['node /home/ubuntu/.c9/bin/c9gdbshim.js "$file" $args'],
                 debugger: "gdb",
                 $debugDefaultState: true,
                 retryCount: 100,
@@ -192,7 +192,7 @@ define(function(require, exports, module) {
          * monitors the shim process and is used by the debugger
          * API to determine if the process is still running.
          * Execute with:
-         * `c9 exec gdb50start; node ~/bin/c9gdbshim.js BIN ARGS`;
+         * `c9 exec gdb50start; node ~/.c9/bin/c9gdbshim.js BIN ARGS`;
          *  c9 exec gdb50stop`
          */
         function gdb50Start(args, reconnect) {


### PR DESCRIPTION
debug50 couldn't find shim in the offline IDE as the path was updated per c9/c9.ide.run.debug@19a5c6b. Also updates Readme as the PRs to the core were merged.